### PR TITLE
[Doc] Typo corrected in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Redux와 RxJs는 현재 점유율을 잃어 가고 있는 상황이지만 그 �
 현재는 XState와 같은 유한 상태기계나 Recoil등의 family등의 최신 패러다임까지 흡수해 1) 상태관리 2) 비동기 3) 반응형 프로그래밍 4) 상태머신이라는 새로운 화두듣을 쉽게 사용할 수 있도록 패키지
 해 나갈 예정입니다.
 
-## What is direffent?
+## What is different?
 
 - Rxjs: Pipe method vs DotChain vs Pipeline operator (TBD)
-- Redux: Why Reducer? Why Redux is verbose? What is benefit using Redux?
+- Redux: Why Reducer? Why Redux is verbose? What are the benefits of using Redux?
 - Props Drill, Context API
 
 ## Read more (TBD)
@@ -36,7 +36,7 @@ Redux와 RxJs는 현재 점유율을 잃어 가고 있는 상황이지만 그 �
 
 ## Goals
 
-> Write less, Do More!
+> Write Less, Do More!
 
 ---
 


### PR DESCRIPTION
README에서 오탈자를 발견하여 수정한 PR입니다.

- 'direffent'는 'different'에 오타로 보여 수정하였습니다. 혹시 몰라 'direffent'를 찾아봤지만, 존재하지 않는 단어로 보입니다.
- 'Write less, Do More'에서 'less'를 대문자로 대체해서 콤마 앞뒤 문장이 동일한 형식을 갖도록 수정했습니다.
- 'What is benefit using Redux?'는 좀 더 의미가 명확하도록 'What are the benefits of using Redux'로 변경하였습니다.